### PR TITLE
Minor Fixes & Improvements

### DIFF
--- a/SpeedandReachFixes/Constants.cs
+++ b/SpeedandReachFixes/Constants.cs
@@ -6,7 +6,7 @@ namespace SpeedandReachFixes
     /// </summary>
     internal struct Constants
     {
-        public const float NullFloat = -0F; // default value assigned to null stat values, indicates that they should be skipped.
+        public const float NullFloat = 0F; // default value assigned to null stat values, indicates that they should be skipped.
         public const int DefaultPriority = -1; // default priority returned when no category matches were found
     }
 }

--- a/SpeedandReachFixes/SettingObjects/WeaponStats.cs
+++ b/SpeedandReachFixes/SettingObjects/WeaponStats.cs
@@ -34,7 +34,7 @@ namespace SpeedandReachFixes.SettingObjects
         public WeaponStats()
         {
             Priority = 0;
-            IsAdditiveModifier = false;
+            IsAdditiveModifier = true;
             Keyword = new();
             Keyword.SetToNull(); // set keyword to null (all 0s)
             Reach = Constants.NullFloat;

--- a/SpeedandReachFixes/SettingObjects/WeaponStats.cs
+++ b/SpeedandReachFixes/SettingObjects/WeaponStats.cs
@@ -14,20 +14,20 @@ namespace SpeedandReachFixes.SettingObjects
     {
         [MaintainOrder]
 
-        [Tooltip("The keyword attached to this weapon type.")]
+        [Tooltip("The keyword/type of weapon that this category applies to.")]
         public FormLink<IKeywordGetter> Keyword;
 
-        [Tooltip("When multiple weapon types apply to the same category, the highest priority wins.")]
+        [Tooltip("If multiple categories could apply to the same weapon, the highest priority one wins.")]
         public int Priority;
 
-        [SettingName("Is Additive Modifier")]
-        [Tooltip("When checked, adds the specified values rather than overwriting them. Negative values will subtract.")]
+        [SettingName("Add to Current Stats")]
+        [Tooltip("When checked, the reach & speed stats in this category are added to the current stats, rather than overwriting them. Negative values are allowed.")]
         public bool IsAdditiveModifier;
 
-        [Tooltip("The range of this weapon. A modifier value of 0 means unchanged.")]
+        [Tooltip("The range of this weapon. Unchanged if this is 0 and \"Add to Current Stats\" is checked.")]
         public float Reach;
 
-        [Tooltip("The speed of this weapon. A modifier value of 0 means unchanged.")]
+        [Tooltip("The speed of this weapon. Unchanged if this is 0 and \"Add to Current Stats\" is checked.")]
         public float Speed;
 
         // Default Constructor

--- a/SpeedandReachFixes/SettingObjects/WeaponStats.cs
+++ b/SpeedandReachFixes/SettingObjects/WeaponStats.cs
@@ -96,7 +96,7 @@ namespace SpeedandReachFixes.SettingObjects
         /// <returns>bool</returns>
         public bool ShouldSkip()
         {
-            return (Keyword.IsNull) || (Reach.Equals(Constants.DefaultPriority) && Speed.Equals(Constants.DefaultPriority));
+            return Keyword.IsNull || (IsAdditiveModifier && Reach.EqualsWithin(Constants.NullFloat) && Speed.EqualsWithin(Constants.NullFloat));
         }
 
         /// <summary>

--- a/SpeedandReachFixes/Settings.cs
+++ b/SpeedandReachFixes/Settings.cs
@@ -27,8 +27,8 @@ namespace SpeedandReachFixes
         public float AttackStrikeAngleModifier = 7F;
 
         // List of WeaponStats objects, each relating to a different weapon keyword.
-        [SettingName("Weapon Groups")]
-        [Tooltip("Change the stats of each weapon group.")]
+        [SettingName("Stat Categories")]
+        [Tooltip("Change the stats of each weapon type.")]
         public List<WeaponStats> WeaponStats { get; set; } = new()
         {
             new WeaponStats(1, false, Skyrim.Keyword.WeapTypeBattleaxe, 0.666667F, 0.8275F),
@@ -63,7 +63,7 @@ namespace SpeedandReachFixes
         private WeaponStats GetHighestPriorityStats(Weapon weapon)
         {
             WeaponStats highestStats = new();
-            var highest = 0;
+            var highest = 0; // the priority level associated with the current highestStats
             foreach (var stats in WeaponStats)
             {
                 var priority = stats.GetPriority(weapon.Keywords);
@@ -80,7 +80,7 @@ namespace SpeedandReachFixes
         public bool ApplyChangesToWeapon(Weapon weapon)
         {
             if (weapon.Data == null || weapon.EditorID == null)
-                return false;
+                return false; // return early if the given weapon is invalid
 
             var stats = GetHighestPriorityStats(weapon);
 
@@ -93,7 +93,7 @@ namespace SpeedandReachFixes
             // Revert any reach changes to giant clubs as they may cause issues with the AI
             if (weapon.EditorID.ContainsInsensitive("GiantClub"))
                 weapon.Data.Reach = 1.3F;
-            return changedReach || changedSpeed;
+            return changedReach || changedSpeed; // returns true if either the speed or the reach values were changed.
         }
     }
 }


### PR DESCRIPTION
- Fixed a bug where the `WeaponStats.ShouldSkip()` function was comparing Reach/Speed values to the `DefaultPriority` constant rather than `NullFloat`, and not checking the `IsAdditiveModifier` variable.  
  This allows null weapon categories to be skipped correctly, and prevents code changes to the `WeaponStats.GetFloat()` function potentially causing stats to be overwritten with zeros.
- `WeaponStats` default constructor now sets `IsAdditiveModifier` to `true`
- Clarified some confusing tooltips & settings menu names  

No `settings.json` files will be harmed by merging this pull request.