### PR TITLE
Prevent fallthrough for zeroed categories

### DIFF
--- a/SpeedandReachFixes/SettingObjects/WeaponStats.cs
+++ b/SpeedandReachFixes/SettingObjects/WeaponStats.cs
@@ -96,7 +96,7 @@ namespace SpeedandReachFixes.SettingObjects
         /// <returns>bool</returns>
         public bool ShouldSkip()
         {
-            return Keyword.IsNull || (IsAdditiveModifier && Reach.EqualsWithin(Constants.NullFloat) && Speed.EqualsWithin(Constants.NullFloat));
+            return Keyword.IsNull;// || (IsAdditiveModifier && Reach.EqualsWithin(Constants.NullFloat) && Speed.EqualsWithin(Constants.NullFloat));
         }
 
         /// <summary>

--- a/SpeedandReachFixes/SettingObjects/WeaponStats.cs
+++ b/SpeedandReachFixes/SettingObjects/WeaponStats.cs
@@ -96,7 +96,7 @@ namespace SpeedandReachFixes.SettingObjects
         /// <returns>bool</returns>
         public bool ShouldSkip()
         {
-            return Keyword.IsNull;// || (IsAdditiveModifier && Reach.EqualsWithin(Constants.NullFloat) && Speed.EqualsWithin(Constants.NullFloat));
+            return Keyword.IsNull;
         }
 
         /// <summary>

--- a/SpeedandReachFixes/Settings.cs
+++ b/SpeedandReachFixes/Settings.cs
@@ -47,19 +47,12 @@ namespace SpeedandReachFixes
             new WeaponStats(1, false, Skyrim.Keyword.WeapTypeSword, 1.1F, 0.83F),
             new WeaponStats(1, false, Skyrim.Keyword.WeapTypeWarAxe, 1F, 0.6F),
             new WeaponStats(1, false, Skyrim.Keyword.WeapTypeWarhammer, 0.6F, 0.8F),
-            new WeaponStats(1, false, Skyrim.Keyword.WeapTypeBow),
-            new WeaponStats(2, true, NewArmoury.Keyword.WeapTypeCestus),
             new WeaponStats(2, true, NewArmoury.Keyword.WeapTypeClaw, Constants.NullFloat, 0.41F),
             new WeaponStats(2, true, NewArmoury.Keyword.WeapTypeHalberd, Constants.NullFloat, 0.58F),
             new WeaponStats(2, true, NewArmoury.Keyword.WeapTypePike, Constants.NullFloat, 0.2F),
             new WeaponStats(2, true, NewArmoury.Keyword.WeapTypeQtrStaff, Constants.NullFloat, 0.25F),
             new WeaponStats(2, true, NewArmoury.Keyword.WeapTypeRapier, Constants.NullFloat, 0.2F),
-            new WeaponStats(2, true, NewArmoury.Keyword.WeapTypeSpear),
             new WeaponStats(2, true, NewArmoury.Keyword.WeapTypeWhip, Constants.NullFloat, 0.5F),
-            // TODO: Find appropriate values for NWTA & WotM unarmed weapons
-            new WeaponStats(2, true, NWTA.Keyword.WeapTypeKatana),
-            new WeaponStats(2, true, NWTA.Keyword.WeapTypeCurvedSword),
-            new WeaponStats(2, true, WayOfTheMonk.Keyword.WeapTypeUnarmed)
         };
 
         [SettingName("Verbose Log")]


### PR DESCRIPTION
Fixes an inconsistency reported by discord user Raineh Daze
- `WeaponStats.ShouldSkip()` returns true only when the attached keyword is null
- This allows categories with no values to be returned by `Settings.GetHighestPriorityStats()`, fixing the fallthrough issue.
- Categories with no values are still handled correctly by the rest of the patcher.